### PR TITLE
Potential fix for code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/lib/discord/shard.ts
+++ b/lib/discord/shard.ts
@@ -4,6 +4,10 @@ import { unstable_cache } from "next/cache";
 import {statusManager} from "./status";
 
 export async function fetchGuildShardId(guildId: string) {
+    // Validate: Discord guild IDs are digits only
+    if (!/^[0-9]+$/.test(guildId)) {
+      return null;
+    }
     return fetch(process.env.INTERNAL_API_BASE_URL + "/status/" + guildId, {
       method: "GET",
     })


### PR DESCRIPTION
Potential fix for [https://github.com/Welcomer-Bot/welcomer-client/security/code-scanning/3](https://github.com/Welcomer-Bot/welcomer-client/security/code-scanning/3)

To fix this vulnerability, we must restrict the impact of user-controlled `guildId` on the requested URL. The ideal solution is to validate `guildId` before using it to construct the URL path. For Discord, a `guildId` should be a string of digits (Discord snowflake IDs are numerical and typically 17-19 digit long strings). You should only proceed with the request if the input is a valid guild ID. A simple and robust validation is to check that `guildId` consists of only digits (`/^[0-9]+$/`). If it fails validation, return `null` (or a safe error) without making the request.

Changes needed:
- In `fetchGuildShardId`: add a check that `guildId` matches `/^[0-9]+$/`.
- If it doesn't, return `null` (or throw an error as appropriate for your API).
- No external library is needed for this basic validation.

Only lines in `lib/discord/shard.ts` within the `fetchGuildShardId` function need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
